### PR TITLE
[주문] - 유저 아이디로 주문 목록 페이징 구현

### DIFF
--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/OrderService.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/OrderService.java
@@ -1,8 +1,14 @@
 package com.yes25.yes255orderpaymentserver.application.service;
 
 import com.yes25.yes255orderpaymentserver.persistance.domain.PreOrder;
+import com.yes25.yes255orderpaymentserver.presentation.dto.response.ReadUserOrderResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderService {
 
     void save(PreOrder preOrder);
+
+    Page<ReadUserOrderResponse> findByUserId(Long userId,
+        Pageable pageable);
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImpl.java
@@ -61,7 +61,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public Page<ReadUserOrderResponse> findByUserId(Long userId,
         Pageable pageable) {
-        Page<Order> orders = orderRepository.findAllByCustomerIdOrderByOrderCreatedAt(userId, pageable);
+        Page<Order> orders = orderRepository.findAllByCustomerIdOrderByOrderCreatedAtDesc(userId, pageable);
 
         List<ReadUserOrderResponse> responses = orders.stream()
             .map(order -> {

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImpl.java
@@ -13,11 +13,15 @@ import com.yes25.yes255orderpaymentserver.persistance.repository.OrderBookReposi
 import com.yes25.yes255orderpaymentserver.persistance.repository.OrderRepository;
 import com.yes25.yes255orderpaymentserver.persistance.repository.OrderStatusRepository;
 import com.yes25.yes255orderpaymentserver.persistance.repository.TakeoutRepository;
+import com.yes25.yes255orderpaymentserver.presentation.dto.response.ReadUserOrderResponse;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,5 +56,20 @@ public class OrderServiceImpl implements OrderService {
         }
 
         orderBookRepository.saveAll(orderBooks);
+    }
+
+    @Override
+    public Page<ReadUserOrderResponse> findByUserId(Long userId,
+        Pageable pageable) {
+        Page<Order> orders = orderRepository.findAllByCustomerIdOrderByOrderCreatedAt(userId, pageable);
+
+        List<ReadUserOrderResponse> responses = orders.stream()
+            .map(order -> {
+                List<OrderBook> orderBooks = orderBookRepository.findByOrder(order);
+                return ReadUserOrderResponse.fromEntity(order, orderBooks);
+            })
+            .toList();
+
+        return new PageImpl<>(responses, pageable, orders.getTotalElements());
     }
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/Order.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/Order.java
@@ -50,6 +50,7 @@ public class Order {
     private String zipCode;
 
     private LocalDateTime orderStartedAt;
+    private LocalDateTime orderCreatedAt;
 
     @Column(nullable = false)
     private LocalDateTime orderDeliveryAt;
@@ -72,7 +73,7 @@ public class Order {
     public Order(String orderId, Long customerId, LocalDateTime orderStartedAt,
         BigDecimal orderTotalAmount,
         Takeout takeout, OrderStatus orderStatus, String addressRaw, String addressDetail,
-        String zipCode, LocalDateTime orderDeliveryAt, List<OrderBook> orderBooks,
+        String zipCode, LocalDateTime orderCreatedAt, LocalDateTime orderDeliveryAt, List<OrderBook> orderBooks,
         String orderUserName, String orderUserEmail, String orderUserPhoneNumber,
         String receiveUserName, String receiveUserEmail, String receiveUserPhoneNumber,
         String reference, Long couponId, BigDecimal points) {
@@ -85,6 +86,7 @@ public class Order {
         this.addressRaw = addressRaw;
         this.addressDetail = addressDetail;
         this.zipCode = zipCode;
+        this.orderCreatedAt = orderCreatedAt;
         this.orderDeliveryAt = orderDeliveryAt;
         this.orderBooks = orderBooks;
         this.orderUserName = orderUserName;

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/PreOrder.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/PreOrder.java
@@ -101,6 +101,7 @@ public class PreOrder {
             .orderStatus(orderStatus)
             .takeout(takeout)
             .addressDetail(addressDetail)
+            .orderCreatedAt(LocalDateTime.now())
             .addressRaw(addressRaw)
             .zipCode(zipcode)
             .reference(reference)

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/repository/OrderBookRepository.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/repository/OrderBookRepository.java
@@ -1,8 +1,11 @@
 package com.yes25.yes255orderpaymentserver.persistance.repository;
 
+import com.yes25.yes255orderpaymentserver.persistance.domain.Order;
 import com.yes25.yes255orderpaymentserver.persistance.domain.OrderBook;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderBookRepository extends JpaRepository<OrderBook, Long> {
 
+    List<OrderBook> findByOrder(Order order);
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/repository/OrderRepository.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/repository/OrderRepository.java
@@ -1,8 +1,11 @@
 package com.yes25.yes255orderpaymentserver.persistance.repository;
 
 import com.yes25.yes255orderpaymentserver.persistance.domain.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, String> {
 
+    Page<Order> findAllByCustomerIdOrderByOrderCreatedAt(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/repository/OrderRepository.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/repository/OrderRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, String> {
 
-    Page<Order> findAllByCustomerIdOrderByOrderCreatedAt(Long userId, Pageable pageable);
+    Page<Order> findAllByCustomerIdOrderByOrderCreatedAtDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/presentation/controller/OrderController.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/presentation/controller/OrderController.java
@@ -1,14 +1,19 @@
 package com.yes25.yes255orderpaymentserver.presentation.controller;
 
+import com.yes25.yes255orderpaymentserver.application.service.OrderService;
 import com.yes25.yes255orderpaymentserver.application.service.queue.OrderProducer;
 import com.yes25.yes255orderpaymentserver.presentation.dto.request.CreateOrderRequest;
 import com.yes25.yes255orderpaymentserver.presentation.dto.response.CreateOrderResponse;
+import com.yes25.yes255orderpaymentserver.presentation.dto.response.ReadUserOrderResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/orders")
@@ -17,11 +22,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
     private final OrderProducer orderProducer;
+    private final OrderService orderService;
 
     @PostMapping
     public ResponseEntity<CreateOrderResponse> createFakeOrder(
         @RequestBody CreateOrderRequest request) {
         return ResponseEntity.ok(orderProducer.sendCreateOrder(request));
+    }
+
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<Page<ReadUserOrderResponse>> findOrderByUserId(
+        Pageable pageable,
+        @PathVariable Long userId) {
+        return ResponseEntity.ok(orderService.findByUserId(userId, pageable));
     }
 
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/response/ReadUserOrderResponse.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/response/ReadUserOrderResponse.java
@@ -1,0 +1,28 @@
+package com.yes25.yes255orderpaymentserver.presentation.dto.response;
+
+import com.yes25.yes255orderpaymentserver.persistance.domain.Order;
+import com.yes25.yes255orderpaymentserver.persistance.domain.OrderBook;
+import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.OrderStatusType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ReadUserOrderResponse(String orderId, LocalDateTime orderCreatedAt, List<Long> productIds,
+                                    BigDecimal amount, OrderStatusType orderStatusType) {
+
+    public static ReadUserOrderResponse fromEntity(Order order, List<OrderBook> orderBooks) {
+        List<Long> productIds = orderBooks.stream()
+            .map(OrderBook::getBookId)
+            .toList();
+
+        return ReadUserOrderResponse.builder()
+            .orderId(order.getOrderId())
+            .orderCreatedAt(order.getOrderCreatedAt())
+            .productIds(productIds)
+            .amount(order.getOrderTotalAmount())
+            .orderStatusType(OrderStatusType.valueOf(order.getOrderStatus().getOrderStatusName()))
+            .build();
+    }
+}


### PR DESCRIPTION
## 연관 이슈
이슈 번호 : 

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 유저 아이디에 따른 주문 목록을 페이징으로 구현하였습니다.
- 주문 리스트를 항상 최신순으로 볼 수 있도록하였습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->
```json
{
    "totalElements": 2,
    "totalPages": 1,
    "first": true,
    "last": true,
    "size": 20,
    "content": [
        {
            "orderId": "order-1718613675938",
            "orderCreatedAt": "2024-06-18T00:53:40",
            "productIds": [
                null,
                null
            ],
            "amount": 164.50,
            "orderStatusType": "WAIT"
        },
        {
            "orderId": "order-1718619752676",
            "orderCreatedAt": "2024-06-16T00:53:44",
            "productIds": [
                1,
                2
            ],
            "amount": 164.50,
            "orderStatusType": "WAIT"
        }
    ],
    "number": 0,
    "sort": [],
    "numberOfElements": 2,
    "pageable": {
        "pageNumber": 0,
        "pageSize": 20,
        "sort": [],
        "offset": 0,
        "paged": true,
        "unpaged": false
    },
    "empty": false
}

```
