### PR TITLE
[결제] - 재고 부족 시, 메시지큐에서 가주문 메세지를 삭제하는 기능 구현

### DIFF
--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/request/DecreaseInStockRequest.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/request/DecreaseInStockRequest.java
@@ -1,0 +1,15 @@
+package com.yes25.yes255orderpaymentserver.application.dto.request;
+
+
+import lombok.Builder;
+
+@Builder
+public record DecreaseInStockRequest(Long bookId, Integer quantity) {
+
+    public static DecreaseInStockRequest of(Long bookId, Integer quantity) {
+        return DecreaseInStockRequest.builder()
+            .bookId(bookId)
+            .quantity(quantity)
+            .build();
+    }
+}

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/PaymentServiceImpl.java
@@ -98,17 +98,14 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     private void checkAndDecreaseInStock(CreatePaymentRequest request) {
-        throw new StockUnavailableException(ErrorStatus.toErrorStatus("주문 부족", 409, LocalDateTime.now()), request.orderId());
+        List<DecreaseInStockRequest> decreaseInStockRequests = new ArrayList<>();
 
+        for (int i = 0; i < request.bookIds().size(); i++) {
+            DecreaseInStockRequest stockRequest = DecreaseInStockRequest.of(request.bookIds().get(i), request.quantities().get(i));
+            decreaseInStockRequests.add(stockRequest);
+        }
 
-//        List<DecreaseInStockRequest> decreaseInStockRequests = new ArrayList<>();
-//
-//        for (int i = 0; i < request.bookIds().size(); i++) {
-//            DecreaseInStockRequest stockRequest = DecreaseInStockRequest.of(request.bookIds().get(i), request.quantities().get(i));
-//            decreaseInStockRequests.add(stockRequest);
-//        }
-//
-//        bookAdaptor.decreaseStock(decreaseInStockRequests);
+        bookAdaptor.decreaseStock(decreaseInStockRequests);
     }
 
     private void sendPaymentDoneMessage(Payment payment) {

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/queue/OrderProducer.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/queue/OrderProducer.java
@@ -23,4 +23,8 @@ public class OrderProducer {
 
         return CreateOrderResponse.fromRequest(preOrder);
     }
+
+    public void sendCancelMessage(String orderId) {
+        rabbitTemplate.convertAndSend("cancelExchange", "cancelRoutingKey", orderId);
+    }
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/common/config/RabbitMQConfig.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/common/config/RabbitMQConfig.java
@@ -31,6 +31,12 @@ public class RabbitMQConfig {
     }
 
     @Bean
+    public Queue preOrderCancelQueue() {
+        return QueueBuilder.durable("cancelQueue")
+            .build();
+    }
+
+    @Bean
     public DirectExchange dlxExchange() {
         return new DirectExchange("dlxExchange");
     }
@@ -46,6 +52,11 @@ public class RabbitMQConfig {
     }
 
     @Bean
+    public DirectExchange cancelExchange() {
+        return new DirectExchange("cancelExchange");
+    }
+
+    @Bean
     public Queue dlqPreOrderQueue() {
         return new Queue("dlq.preOrderQueue");
     }
@@ -53,6 +64,13 @@ public class RabbitMQConfig {
     @Bean
     public Queue dlqPaymentQueue() {
         return new Queue("dlq.paymentQueue");
+    }
+
+    @Bean
+    public Binding cancelBinding(Queue preOrderCancelQueue, DirectExchange cancelExchange) {
+        return BindingBuilder.bind(preOrderCancelQueue)
+            .to(cancelExchange)
+            .with("cancelRoutingKey");
     }
 
     @Bean

--- a/src/main/java/com/yes25/yes255orderpaymentserver/common/decoder/CustomErrorDecoder.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/common/decoder/CustomErrorDecoder.java
@@ -31,11 +31,11 @@ public class CustomErrorDecoder implements ErrorDecoder {
     }
 
     private Exception handleException(Response response, String responseBody) {
-        if (response.status() == 409) {
-            log.error("상품 재고가 부족합니다. {}", responseBody);
-            return new StockUnavailableException(
-                ErrorStatus.toErrorStatus(responseBody, response.status(), LocalDateTime.now()));
-        }
+//        if (response.status() == 409) {
+//            log.error("상품 재고가 부족합니다. {}", responseBody);
+//            return new StockUnavailableException(
+//                ErrorStatus.toErrorStatus(responseBody, response.status(), LocalDateTime.now()));
+//        }
 
         if (response.status() == 400) {
             log.error("클라이언트 요청에서 에러가 발생하였습니다. 상태 코드: 400, 응답 본문: {}", responseBody);

--- a/src/main/java/com/yes25/yes255orderpaymentserver/common/exception/StockUnavailableException.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/common/exception/StockUnavailableException.java
@@ -1,11 +1,15 @@
 package com.yes25.yes255orderpaymentserver.common.exception;
 
 import com.yes25.yes255orderpaymentserver.common.exception.payload.ErrorStatus;
+import lombok.Getter;
 
+@Getter
 public class StockUnavailableException extends ApplicationException{
+    private final String orderId;
 
     public StockUnavailableException(
-        ErrorStatus errorStatus) {
+        ErrorStatus errorStatus, String orderId) {
         super(errorStatus);
+        this.orderId = orderId;
     }
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/infrastructure/adaptor/BookAdaptor.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/infrastructure/adaptor/BookAdaptor.java
@@ -1,6 +1,8 @@
 package com.yes25.yes255orderpaymentserver.infrastructure.adaptor;
 
+import com.yes25.yes255orderpaymentserver.application.dto.request.DecreaseInStockRequest;
 import com.yes25.yes255orderpaymentserver.common.config.FeignClientConfig;
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,6 +11,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 @FeignClient(name = "bookAdaptor", url = "http://localhost:8061/books", configuration = FeignClientConfig.class)
 public interface BookAdaptor {
 
-    @PatchMapping("/{bookId}")
-    void decreaseStock(@PathVariable Long bookId, @RequestParam Integer quantity);
+    @PatchMapping
+    void decreaseStock(List<DecreaseInStockRequest> decreaseInStockRequests);
 }


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 재고 부족 시, 가주문 취소 메세지를 발행합니다.
- 가주문 취소 메세지를 구독하는 곳에서 가주문큐를 최대 비어있을때까지 반복합니다.
- 가주문 취소 메세지의 `orderId`와 가주문큐의 `orderId`가 일치하면 해당 가주문 메세지를 소비하도록 유도합니다. (= 메세지 삭제)
- 일치하지 않다면 다시 가주문큐에 메세지를 넣어줍니다.
- 가주문큐가 비어있다면 종료합니다.

## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->