### PR TITLE
[주문] - 주문 확정 중 예외 발생 시, 토스 API에 결제 취소 요청을 보내는 기능 구현

### DIFF
--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/request/CancelPaymentRequest.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/request/CancelPaymentRequest.java
@@ -1,0 +1,14 @@
+package com.yes25.yes255orderpaymentserver.application.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record CancelPaymentRequest(String cancelReason, Integer cancelAmount) {
+
+    public static CancelPaymentRequest from(String cancelReason, Integer cancelAmount) {
+        return CancelPaymentRequest.builder()
+            .cancelReason(cancelReason)
+            .cancelAmount(cancelAmount)
+            .build();
+    }
+}

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/request/StockRequest.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/request/StockRequest.java
@@ -17,4 +17,12 @@ public record StockRequest(List<Long> bookIdList, List<Integer> quantityList, Op
             .operationType(operationType)
             .build();
     }
+
+    public static StockRequest of(List<Long> bookIdList, List<Integer> quantityList, OperationType operationType) {
+        return StockRequest.builder()
+            .bookIdList(bookIdList)
+            .quantityList(quantityList)
+            .operationType(operationType)
+            .build();
+    }
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/response/SuccessPaymentResponse.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/response/SuccessPaymentResponse.java
@@ -1,16 +1,25 @@
 package com.yes25.yes255orderpaymentserver.application.dto.response;
 
 import com.yes25.yes255orderpaymentserver.persistance.domain.Payment;
+import com.yes25.yes255orderpaymentserver.presentation.dto.request.CreatePaymentRequest;
+import jakarta.persistence.criteria.CriteriaBuilder.In;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record SuccessPaymentResponse(String orderId, String paymentKey, Integer paymentAmount) {
+public record SuccessPaymentResponse(String orderId,
+                                     String paymentKey,
+                                     Integer paymentAmount,
+                                     List<Long> bookIdList,
+                                     List<Integer> quantityList) {
 
-    public static SuccessPaymentResponse fromEntity(Payment payment) {
+    public static SuccessPaymentResponse of(Payment payment, CreatePaymentRequest request) {
         return SuccessPaymentResponse.builder()
             .orderId(payment.getOrderId())
             .paymentKey(payment.getPaymentKey())
             .paymentAmount(payment.getPaymentAmount().intValue())
+            .bookIdList(request.bookIds())
+            .quantityList(request.quantities())
             .build();
     }
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/response/SuccessPaymentResponse.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/response/SuccessPaymentResponse.java
@@ -4,12 +4,13 @@ import com.yes25.yes255orderpaymentserver.persistance.domain.Payment;
 import lombok.Builder;
 
 @Builder
-public record SuccessPaymentResponse(String orderId, String paymentKey) {
+public record SuccessPaymentResponse(String orderId, String paymentKey, Integer paymentAmount) {
 
     public static SuccessPaymentResponse fromEntity(Payment payment) {
         return SuccessPaymentResponse.builder()
             .orderId(payment.getOrderId())
             .paymentKey(payment.getPaymentKey())
+            .paymentAmount(payment.getPaymentAmount().intValue())
             .build();
     }
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/OrderService.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.yes25.yes255orderpaymentserver.application.service;
 
+import com.yes25.yes255orderpaymentserver.application.dto.response.SuccessPaymentResponse;
 import com.yes25.yes255orderpaymentserver.persistance.domain.PreOrder;
 import com.yes25.yes255orderpaymentserver.presentation.dto.response.ReadUserOrderAllResponse;
 import com.yes25.yes255orderpaymentserver.presentation.dto.response.ReadUserOrderResponse;
@@ -9,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface OrderService {
 
-    void createOrder(PreOrder preOrder, BigDecimal purePrice);
+    void createOrder(PreOrder preOrder, BigDecimal purePrice, SuccessPaymentResponse successPaymentResponse);
 
     Page<ReadUserOrderAllResponse> findByUserId(Long userId,
         Pageable pageable);

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/PaymentService.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/PaymentService.java
@@ -7,5 +7,6 @@ public interface PaymentService {
 
     CreatePaymentResponse createPayment(CreatePaymentRequest request);
 
-    void cancelPayment(String paymentKey, String message);
+    void cancelPayment(String paymentKey, String cancelReason, Integer paymentAmount,
+        String orderId);
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/event/OrderCreateEvent.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/event/OrderCreateEvent.java
@@ -1,0 +1,21 @@
+package com.yes25.yes255orderpaymentserver.application.service.event;
+
+import com.yes25.yes255orderpaymentserver.application.dto.response.SuccessPaymentResponse;
+import com.yes25.yes255orderpaymentserver.persistance.domain.PreOrder;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record OrderCreateEvent(List<Long> bookIdList, List<Integer> quantityList, String paymentKey, String orderId, Integer cancelAmount) {
+
+
+    public static OrderCreateEvent of(PreOrder preOrder, SuccessPaymentResponse response) {
+        return OrderCreateEvent.builder()
+            .bookIdList(preOrder.getBookIds())
+            .quantityList(preOrder.getQuantities())
+            .orderId(preOrder.getPreOrderId())
+            .paymentKey(response.paymentKey())
+            .cancelAmount(response.paymentAmount())
+            .build();
+    }
+}

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/event/OrderEventListener.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/event/OrderEventListener.java
@@ -1,0 +1,42 @@
+package com.yes25.yes255orderpaymentserver.application.service.event;
+
+import com.yes25.yes255orderpaymentserver.application.dto.request.StockRequest;
+import com.yes25.yes255orderpaymentserver.application.dto.request.enumtype.OperationType;
+import com.yes25.yes255orderpaymentserver.application.service.PaymentService;
+import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.BookAdaptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventListener {
+
+    private final BookAdaptor bookAdaptor;
+    private final PaymentService paymentService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+    public void onOrderCreatEventAfterRollback(OrderCreateEvent event) {
+        log.info("주문이 롤백되었습니다. 재고를 복구합니다. 책 ID : {}, 재고 : {}", event.bookIdList(), event.quantityList());
+
+        increaseBooks(event);
+        cancelPayment(event);
+    }
+
+    private void cancelPayment(OrderCreateEvent event) {
+        paymentService.cancelPayment(event.paymentKey(), "주문 롤백으로 인한 취소", event.cancelAmount(),
+            event.orderId());
+    }
+
+    private void increaseBooks(OrderCreateEvent event) {
+        StockRequest stockRequest = StockRequest.of(event.bookIdList(), event.quantityList(),
+            OperationType.INCREASE);
+
+        bookAdaptor.updateStock(stockRequest);
+    }
+}

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImpl.java
@@ -1,6 +1,8 @@
 package com.yes25.yes255orderpaymentserver.application.service.impl;
 
+import com.yes25.yes255orderpaymentserver.application.dto.response.SuccessPaymentResponse;
 import com.yes25.yes255orderpaymentserver.application.service.OrderService;
+import com.yes25.yes255orderpaymentserver.application.service.event.OrderCreateEvent;
 import com.yes25.yes255orderpaymentserver.common.exception.EntityNotFoundException;
 import com.yes25.yes255orderpaymentserver.common.exception.payload.ErrorStatus;
 import com.yes25.yes255orderpaymentserver.persistance.domain.Order;
@@ -21,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -37,9 +40,10 @@ public class OrderServiceImpl implements OrderService {
     private final OrderStatusRepository orderStatusRepository;
     private final TakeoutRepository takeoutRepository;
     private final OrderBookRepository orderBookRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
-    public void createOrder(PreOrder preOrder, BigDecimal purePrice) {
+    public void createOrder(PreOrder preOrder, BigDecimal purePrice, SuccessPaymentResponse response) {
         log.info("결제가 완료되어 주문을 확정하는 중입니다. : {}", preOrder);
         OrderStatus orderStatus = orderStatusRepository.findByOrderStatusName(OrderStatusType.WAIT.name())
             .orElseThrow(() -> new EntityNotFoundException(
@@ -59,6 +63,7 @@ public class OrderServiceImpl implements OrderService {
         }
 
         orderBookRepository.saveAll(orderBooks);
+        eventPublisher.publishEvent(OrderCreateEvent.of(preOrder, response));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/PaymentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.yes25.yes255orderpaymentserver.application.service.impl;
 
+import com.yes25.yes255orderpaymentserver.application.dto.request.CancelPaymentRequest;
 import com.yes25.yes255orderpaymentserver.application.dto.request.StockRequest;
 import com.yes25.yes255orderpaymentserver.application.dto.request.enumtype.OperationType;
 import com.yes25.yes255orderpaymentserver.application.dto.response.SuccessPaymentResponse;
@@ -7,6 +8,7 @@ import com.yes25.yes255orderpaymentserver.application.service.PaymentService;
 import com.yes25.yes255orderpaymentserver.common.exception.FeignClientException;
 import com.yes25.yes255orderpaymentserver.common.exception.StockUnavailableException;
 import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.BookAdaptor;
+import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.TossAdaptor;
 import com.yes25.yes255orderpaymentserver.persistance.domain.Payment;
 import com.yes25.yes255orderpaymentserver.persistance.repository.PaymentRepository;
 import com.yes25.yes255orderpaymentserver.presentation.dto.request.CreatePaymentRequest;
@@ -38,6 +40,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final RabbitTemplate rabbitTemplate;
     private final PaymentRepository paymentRepository;
     private final BookAdaptor bookAdaptor;
+    private final TossAdaptor tossAdaptor;
 
     @Value("${payment.secret}")
     private String paymentSecretKey;
@@ -54,8 +57,12 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
-    public void cancelPayment(String paymentKey, String message) {
+    public void cancelPayment(String paymentKey, String cancelReason, Integer cancelAmount,
+        String orderId) {
+        CancelPaymentRequest request = CancelPaymentRequest.from(cancelReason, cancelAmount);
+        String authorization = "Basic " + Base64.getEncoder().encodeToString((paymentSecretKey + ":").getBytes());
 
+        tossAdaptor.cancelPayment(paymentKey, request, authorization, orderId);
     }
 
     private CreatePaymentResponse processingPayment(CreatePaymentRequest request) {

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/PaymentServiceImpl.java
@@ -96,7 +96,7 @@ public class PaymentServiceImpl implements PaymentService {
             if (isSuccess) {
                 Payment payment = savePayment(jsonObject);
                 log.info("결제가 성공적으로 이루어졌습니다. {}", payment);
-                sendPaymentDoneMessage(payment);
+                sendPaymentDoneMessage(payment, request);
             }
         } catch (Exception e) {
             log.error("error : ", e);
@@ -112,8 +112,8 @@ public class PaymentServiceImpl implements PaymentService {
         bookAdaptor.updateStock(stockRequest);
     }
 
-    private void sendPaymentDoneMessage(Payment payment) {
-        SuccessPaymentResponse response = SuccessPaymentResponse.fromEntity(payment);
+    private void sendPaymentDoneMessage(Payment payment, CreatePaymentRequest request) {
+        SuccessPaymentResponse response = SuccessPaymentResponse.of(payment, request);
 
         rabbitTemplate.convertAndSend("paymentExchange", "paymentRoutingKey", response);
     }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/queue/OrderConsumer.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/queue/OrderConsumer.java
@@ -1,12 +1,15 @@
 package com.yes25.yes255orderpaymentserver.application.service.queue;
 
+import com.yes25.yes255orderpaymentserver.application.dto.request.StockRequest;
 import com.yes25.yes255orderpaymentserver.application.dto.request.UpdatePointMessage;
 import com.yes25.yes255orderpaymentserver.application.dto.request.UpdatePointRequest;
+import com.yes25.yes255orderpaymentserver.application.dto.request.enumtype.OperationType;
 import com.yes25.yes255orderpaymentserver.application.dto.response.SuccessPaymentResponse;
 import com.yes25.yes255orderpaymentserver.application.service.OrderService;
 import com.yes25.yes255orderpaymentserver.application.service.PaymentService;
 import com.yes25.yes255orderpaymentserver.common.exception.PaymentException;
 import com.yes25.yes255orderpaymentserver.common.exception.payload.ErrorStatus;
+import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.BookAdaptor;
 import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.UserAdaptor;
 import com.yes25.yes255orderpaymentserver.persistance.domain.PreOrder;
 import java.math.BigDecimal;
@@ -16,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.context.event.EventListener;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
@@ -30,6 +32,7 @@ public class OrderConsumer {
     private final RabbitTemplate rabbitTemplate;
     private final OrderService orderService;
     private final UserAdaptor userAdaptor;
+    private final BookAdaptor bookAdaptor;
     private final OrderProducer orderProducer;
     private final PaymentService paymentService;
 
@@ -38,7 +41,7 @@ public class OrderConsumer {
      *                          적립은 타 서버 완료 시 확인이 가능합니다. 현재는 주석처리 하였습니다.
      */
     @RabbitListener(queues = "paymentQueue")
-    @Retryable(maxAttempts = 5, backoff = @Backoff(delay = 2000), retryFor = PaymentException.class, noRetryFor = RuntimeException.class)
+    @Retryable(maxAttempts = 5, backoff = @Backoff(delay = 2000), retryFor = PaymentException.class)
     public void receivePayment(SuccessPaymentResponse response) {
         PreOrder preOrder = (PreOrder) rabbitTemplate.receiveAndConvert("preOrderQueue");
 
@@ -65,7 +68,10 @@ public class OrderConsumer {
 
     @Recover
     public void recover(PaymentException e, SuccessPaymentResponse response) {
-        log.error("최대 재시도 횟수 초과. 결제 취소 요청을 보냅니다.");
+        log.error("최대 재시도 횟수 초과. 재고를 복구하고 결제 취소 요청을 보냅니다. 주문 ID : {}", e.getOrderId());
+        StockRequest request = StockRequest.of(response.bookIdList(), response.quantityList(), OperationType.INCREASE);
+
+        bookAdaptor.updateStock(request);
         paymentService.cancelPayment(e.getPaymentKey(), "결제 내역과 일치하는 주문이 없음", e.getPaymentAmount(), e.getOrderId());
     }
 

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/queue/OrderConsumer.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/queue/OrderConsumer.java
@@ -4,6 +4,7 @@ import com.yes25.yes255orderpaymentserver.application.dto.request.UpdatePointMes
 import com.yes25.yes255orderpaymentserver.application.dto.request.UpdatePointRequest;
 import com.yes25.yes255orderpaymentserver.application.dto.response.SuccessPaymentResponse;
 import com.yes25.yes255orderpaymentserver.application.service.OrderService;
+import com.yes25.yes255orderpaymentserver.application.service.PaymentService;
 import com.yes25.yes255orderpaymentserver.common.exception.PaymentException;
 import com.yes25.yes255orderpaymentserver.common.exception.payload.ErrorStatus;
 import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.UserAdaptor;
@@ -15,6 +16,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.event.EventListener;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,19 +31,22 @@ public class OrderConsumer {
     private final OrderService orderService;
     private final UserAdaptor userAdaptor;
     private final OrderProducer orderProducer;
+    private final PaymentService paymentService;
 
     /**
      * @throws PaymentException 결제 완료 후, 결제의 preOrderId와 주문의 orderId가 일치하지 않으면 발생합니다. 재고 확인 및 포인트
      *                          적립은 타 서버 완료 시 확인이 가능합니다. 현재는 주석처리 하였습니다.
      */
     @RabbitListener(queues = "paymentQueue")
+    @Retryable(maxAttempts = 5, backoff = @Backoff(delay = 2000), retryFor = PaymentException.class, noRetryFor = RuntimeException.class)
     public void receivePayment(SuccessPaymentResponse response) {
         PreOrder preOrder = (PreOrder) rabbitTemplate.receiveAndConvert("preOrderQueue");
 
         if (Objects.isNull(preOrder)) {
             log.error("주문 정보를 가져오지 못했습니다.");
             throw new PaymentException(
-                ErrorStatus.toErrorStatus("결제 큐에서 주문을 가져오지 못했습니다.", 404, LocalDateTime.now()), response.paymentKey());
+                ErrorStatus.toErrorStatus("결제 큐에서 주문을 가져오지 못했습니다.", 404,
+                    LocalDateTime.now()), response.paymentKey(), response.orderId(), response.paymentAmount());
         }
 
         if (!preOrder.getPreOrderId().equals(response.orderId())) {
@@ -47,18 +55,23 @@ public class OrderConsumer {
 
             throw new PaymentException(
                 ErrorStatus.toErrorStatus("결제 큐에서 해당하는 주문를 찾을 수 없습니다.", 404,
-                    LocalDateTime.now()), response.paymentKey());
+                    LocalDateTime.now()), response.paymentKey(), response.orderId(), response.paymentAmount());
         }
 
         BigDecimal purePrice = preOrder.calculatePurePrice();
-        orderService.createOrder(preOrder, purePrice);
+        orderService.createOrder(preOrder, purePrice, response);
         orderProducer.sendOrderDone(preOrder, purePrice);
     }
 
+    @Recover
+    public void recover(PaymentException e, SuccessPaymentResponse response) {
+        log.error("최대 재시도 횟수 초과. 결제 취소 요청을 보냅니다.");
+        paymentService.cancelPayment(e.getPaymentKey(), "결제 내역과 일치하는 주문이 없음", e.getPaymentAmount(), e.getOrderId());
+    }
 
     /**
      * @param updatePointMessage 주문 확정을 알리는 메세지
-     * */
+     */
     @RabbitListener(queues = "orderDoneQueue")
     private void updatePoints(UpdatePointMessage updatePointMessage) {
         UpdatePointRequest updatePointRequest = UpdatePointRequest.from(updatePointMessage);
@@ -67,7 +80,7 @@ public class OrderConsumer {
 
     /**
      * @param orderId 가주문 Id
-     * */
+     */
     @RabbitListener(queues = "cancelQueue")
     public void receiveCancelMessage(String orderId) {
 

--- a/src/main/java/com/yes25/yes255orderpaymentserver/common/config/RabbitMQConfig.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/common/config/RabbitMQConfig.java
@@ -1,5 +1,6 @@
 package com.yes25.yes255orderpaymentserver.common.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class RabbitMQConfig {
 
     @Bean

--- a/src/main/java/com/yes25/yes255orderpaymentserver/common/config/RetryConfig.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/common/config/RetryConfig.java
@@ -1,0 +1,10 @@
+package com.yes25.yes255orderpaymentserver.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}
+

--- a/src/main/java/com/yes25/yes255orderpaymentserver/common/exception/PaymentException.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/common/exception/PaymentException.java
@@ -6,9 +6,14 @@ import lombok.Getter;
 @Getter
 public class PaymentException extends ApplicationException {
     private final String paymentKey;
+    private final String orderId;
+    private final Integer paymentAmount;
 
-    public PaymentException(ErrorStatus errorStatus, String paymentKey) {
+    public PaymentException(ErrorStatus errorStatus, String paymentKey, String orderId,
+        Integer paymentAmount) {
         super(errorStatus);
         this.paymentKey = paymentKey;
+        this.orderId = orderId;
+        this.paymentAmount = paymentAmount;
     }
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/common/handler/GlobalRestControllerAdvice.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/common/handler/GlobalRestControllerAdvice.java
@@ -1,9 +1,7 @@
-package com.yes25.yes255orderpaymentserver.common.advice;
+package com.yes25.yes255orderpaymentserver.common.handler;
 
-import com.yes25.yes255orderpaymentserver.application.service.PaymentService;
 import com.yes25.yes255orderpaymentserver.application.service.queue.OrderProducer;
 import com.yes25.yes255orderpaymentserver.common.exception.ApplicationException;
-import com.yes25.yes255orderpaymentserver.common.exception.PaymentException;
 import com.yes25.yes255orderpaymentserver.common.exception.StockUnavailableException;
 import com.yes25.yes255orderpaymentserver.common.exception.payload.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -15,20 +13,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RequiredArgsConstructor
 public class GlobalRestControllerAdvice {
 
-    private final PaymentService paymentService;
     private final OrderProducer orderProducer;
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ErrorStatus> handleApplicationException(ApplicationException e) {
         ErrorStatus errorStatus = e.getErrorStatus();
-
-        return new ResponseEntity<>(errorStatus, errorStatus.toHttpStatus());
-    }
-
-    @ExceptionHandler(PaymentException.class)
-    public ResponseEntity<ErrorStatus> handlePaymentException(PaymentException e) {
-        ErrorStatus errorStatus = e.getErrorStatus();
-        paymentService.cancelPayment(e.getPaymentKey(), e.getErrorStatus().message());
 
         return new ResponseEntity<>(errorStatus, errorStatus.toHttpStatus());
     }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/infrastructure/adaptor/TossAdaptor.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/infrastructure/adaptor/TossAdaptor.java
@@ -1,0 +1,16 @@
+package com.yes25.yes255orderpaymentserver.infrastructure.adaptor;
+
+import com.yes25.yes255orderpaymentserver.application.dto.request.CancelPaymentRequest;
+import com.yes25.yes255orderpaymentserver.common.config.FeignClientConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "tossAdaptor", url = "https://api.tosspayments.com/v1", configuration = FeignClientConfig.class)
+public interface TossAdaptor {
+
+    @PostMapping("/payments/{paymentsKey}/cancel")
+    void cancelPayment(@PathVariable String paymentsKey, @RequestBody CancelPaymentRequest request, @RequestHeader String authorization, @RequestHeader String idempotencyKey);
+}

--- a/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/response/CreateOrderResponse.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/response/CreateOrderResponse.java
@@ -8,7 +8,8 @@ import lombok.Builder;
 public record CreateOrderResponse(String orderId,
                                   Integer totalAmount,
                                   List<Long> bookIds,
-                                  List<Integer> quantities) {
+                                  List<Integer> quantities,
+                                  Integer points) {
 
     public static CreateOrderResponse fromRequest(PreOrder preOrder) {
         return CreateOrderResponse.builder()
@@ -16,6 +17,7 @@ public record CreateOrderResponse(String orderId,
             .totalAmount(preOrder.getOrderTotalAmount().intValue())
             .bookIds(preOrder.getBookIds())
             .quantities(preOrder.getQuantities())
+            .points(preOrder.getPoints().intValue())
             .build();
     }
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/response/ReadUserOrderAllResponse.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/response/ReadUserOrderAllResponse.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 @Builder
 public record ReadUserOrderAllResponse(String orderId,
                                        List<Long> productIds,
+                                       List<Integer> quantities,
                                        LocalDate orderCreatedAt,
                                        LocalDate orderDeliveryAt,
                                        BigDecimal amount,
@@ -22,12 +23,17 @@ public record ReadUserOrderAllResponse(String orderId,
             .map(OrderBook::getBookId)
             .toList();
 
+        List<Integer> quantities = orderBooks.stream()
+            .map(OrderBook::getOrderProductQuantity)
+            .toList();
+
         return ReadUserOrderAllResponse.builder()
             .orderId(order.getOrderId())
             .orderCreatedAt(LocalDate.from(order.getOrderCreatedAt()))
             .orderDeliveryAt(LocalDate.from(order.getOrderDeliveryAt()))
             .productIds(productIds)
             .amount(order.getOrderTotalAmount())
+            .quantities(quantities)
             .orderStatusType(OrderStatusType.valueOf(order.getOrderStatus().getOrderStatusName()))
             .build();
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -48,3 +48,6 @@ eureka:
 
 jwt:
   secret: this-is-secret-key-yeah-ho-hu-yea-yes-hi-bye
+
+payment:
+  secret: ${PAYMENT_SECRET}


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 주문 확정 중 예외 발생 시, 결제 취소 요청을 보내는 기능 구현하였습니다.
- 결제완료 후, 가주문의 orderId와 결제의 orderId를 비교하여 최대 5회까지 일치하지 않으면 재고 증가 처리 및 결제 취소를 하도록 구현하였습니다.
- 결제 완료 후, 주문 확정 트랜잭션에서 예외가 발생하면 재고 증가 처리 및 결제 취소를 하도록 구현하였습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [ ] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->

<img width="1309" alt="image" src="https://github.com/nhnacademy-be6-yes-25-5/yes-25-5-order-payment-server/assets/105257665/02ee9212-d049-49a1-a65c-099297fa3f75">
