### PR TITLE
[결제] - payment큐가 죽는 이슈 해결

### DIFF
--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/PaymentServiceImpl.java
@@ -115,7 +115,7 @@ public class PaymentServiceImpl implements PaymentService {
     private void sendPaymentDoneMessage(Payment payment, CreatePaymentRequest request) {
         SuccessPaymentResponse response = SuccessPaymentResponse.of(payment, request);
 
-        rabbitTemplate.convertAndSend("paymentExchange", "paymentRoutingKey", response);
+        rabbitTemplate.convertAndSend("payExchange", "payRoutingKey", response);
     }
 
     private Payment savePayment(JSONObject jsonObject) {

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/queue/OrderConsumer.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/queue/OrderConsumer.java
@@ -36,7 +36,7 @@ public class OrderConsumer {
      * @throws PaymentException 결제 완료 후, 결제의 preOrderId와 주문의 orderId가 일치하지 않으면 발생합니다. 재고 확인 및 포인트
      *                          적립은 타 서버 완료 시 확인이 가능합니다. 현재는 주석처리 하였습니다.
      */
-    @RabbitListener(queues = "paymentQueue")
+    @RabbitListener(queues = "payQueue")
     @Retryable(maxAttempts = 5, backoff = @Backoff(delay = 2000), retryFor = PaymentException.class)
     public void receivePayment(SuccessPaymentResponse response) {
         PreOrder preOrder = (PreOrder) rabbitTemplate.receiveAndConvert("preOrderQueue");

--- a/src/main/java/com/yes25/yes255orderpaymentserver/common/config/RabbitMQConfig.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/common/config/RabbitMQConfig.java
@@ -23,12 +23,9 @@ public class RabbitMQConfig {
             .withArgument("x-dead-letter-routing-key", "dlx.preOrderQueue")
             .build();
     }
-
     @Bean
-    public Queue paymentQueue() {
-        return QueueBuilder.durable("paymentQueue")
-            .withArgument("x-dead-letter-exchange", "dlxExchange")
-            .withArgument("x-dead-letter-routing-key", "dlx.paymentQueue")
+    public Queue payQueue() {
+        return QueueBuilder.durable("payQueue")
             .build();
     }
 
@@ -51,9 +48,14 @@ public class RabbitMQConfig {
         return new DirectExchange("dlxExchange");
     }
 
+//    @Bean
+//    public DirectExchange paymentExchange() {
+//        return new DirectExchange("paymentExchange");
+//    }
+
     @Bean
-    public DirectExchange paymentExchange() {
-        return new DirectExchange("paymentExchange");
+    public DirectExchange payExchange() {
+        return new DirectExchange("payExchange");
     }
 
     @Bean
@@ -76,10 +78,10 @@ public class RabbitMQConfig {
         return new Queue("dlx.preOrderQueue");
     }
 
-    @Bean
-    public Queue dlqPaymentQueue() {
-        return new Queue("dlx.paymentQueue");
-    }
+//    @Bean
+//    public Queue dlqPaymentQueue() {
+//        return new Queue("dlx.paymentQueue");
+//    }
 
     @Bean
     public Queue dlqOrderDoneQueue() {
@@ -101,10 +103,10 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    public Binding paymentBinding(Queue paymentQueue, DirectExchange paymentExchange) {
-        return BindingBuilder.bind(paymentQueue)
-            .to(paymentExchange)
-            .with("paymentRoutingKey");
+    public Binding payBinding(Queue payQueue, DirectExchange payExchange) {
+        return BindingBuilder.bind(payQueue)
+            .to(payExchange)
+            .with("payRoutingKey");
     }
 
     @Bean
@@ -120,14 +122,6 @@ public class RabbitMQConfig {
             .bind(dlqPreOrderQueue)
             .to(dlxExchange)
             .with("dlx.preOrderQueue");
-    }
-
-    @Bean
-    public Binding dlxPaymentBinding(Queue dlqPaymentQueue, DirectExchange dlxExchange) {
-        return BindingBuilder
-            .bind(dlqPaymentQueue)
-            .to(dlxExchange)
-            .with("dlx.paymentQueue");
     }
 
     @Bean


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [x] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 모종의 이유로 paymentQueue가 죽어서 결제 완료를해도 메세지가 발행되지 않았습니다.
- 새로운 큐를 만들어 해결하였습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->