### PR TITLE
[결제] - 결제 실패 시, 주문 성공 처리 후 만료시간까지 재시도하는 기능 추가

### DIFF
--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/response/SuccessPaymentResponse.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/response/SuccessPaymentResponse.java
@@ -16,7 +16,7 @@ public record SuccessPaymentResponse(String orderId,
 
     public static SuccessPaymentResponse of(Payment payment, CreatePaymentRequest request) {
         return SuccessPaymentResponse.builder()
-            .orderId(payment.getPreOrderId())
+            .orderId(request.orderId())
             .paymentKey(payment.getPaymentKey())
             .paymentAmount(Integer.valueOf(request.amount()))
             .bookIdList(request.bookIds())

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/response/SuccessPaymentResponse.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/dto/response/SuccessPaymentResponse.java
@@ -18,7 +18,7 @@ public record SuccessPaymentResponse(String orderId,
         return SuccessPaymentResponse.builder()
             .orderId(payment.getPreOrderId())
             .paymentKey(payment.getPaymentKey())
-            .paymentAmount(payment.getPaymentAmount().intValue())
+            .paymentAmount(Integer.valueOf(request.amount()))
             .bookIdList(request.bookIds())
             .paymentProvider(request.paymentProvider())
             .quantityList(request.quantities())

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/AdminOrderServiceImpl.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/AdminOrderServiceImpl.java
@@ -129,7 +129,7 @@ public class AdminOrderServiceImpl implements AdminOrderService {
 
         if (request.status().equals(CancelStatus.ACCESS)) {
             paymentContext.cancelPayment(refund.getOrder().getPayment().getPaymentKey(), "고객 요청",
-                refund.getOrder().getPayment().getPaymentAmount().intValue(), refund.getOrder().getOrderId(), request.paymentProvider().name().toLowerCase());
+                refund.getOrder().getPayment().getPaymentDetail().getPaymentAmount().intValue(), refund.getOrder().getOrderId(), request.paymentProvider().name().toLowerCase());
 
             log.info("주문이 관리자에 의해 성공적으로 환불되었습니다.");
         } else {

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImpl.java
@@ -87,7 +87,7 @@ public class OrderServiceImpl implements OrderService {
 
         orderCouponRepository.saveAll(orderCoupons);
 
-        Payment payment = paymentRepository.findByPreOrderId(savedOrder.getOrderId())
+        Payment payment = paymentRepository.findByPaymentKey(response.paymentKey())
             .orElseThrow(() -> new EntityNotFoundException(ErrorStatus.toErrorStatus(
                 "해당 주문에 대한 결제 정보를 찾을 수 없습니다. 주문 ID : " + savedOrder.getOrderId(), 404, LocalDateTime.now())));
         payment.addOrder(savedOrder);

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/queue/producer/MessageProducer.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/queue/producer/MessageProducer.java
@@ -40,6 +40,10 @@ public class MessageProducer {
             UpdatePointMessage updatePointMessage = UpdatePointMessage.of(preOrder.getPoints(),
                 purePrice, OperationType.USE);
 
+            sendMessage("pointUsedExchange", "pointUsedRoutingKey", updatePointMessage, authToken);
+        }
+
+        if (!CollectionUtils.isEmpty(preOrder.getCouponIds())) {
             List<UpdateCouponRequest> updateCouponRequests = new ArrayList<>();
             for (Long couponId : preOrder.getCouponIds()) {
                 UpdateCouponRequest updateCouponRequest = UpdateCouponRequest.from(
@@ -48,11 +52,8 @@ public class MessageProducer {
                 updateCouponRequests.add(updateCouponRequest);
             }
 
-            sendMessage("pointUsedExchange", "pointUsedRoutingKey", updatePointMessage, authToken);
             sendMessage("couponUsedExchange", "couponUsedRoutingKey", updateCouponRequests,
                 authToken);
-
-            log.info("쿠폰 사용, 포인트 차감 및 적립 메세지가 발행되었습니다.");
         }
 
         List<UpdateUserCartQuantityRequest> userCartQuantityRequests = createUserCartQuantityRequests(

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/strategy/payment/PaymentRetryService.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/strategy/payment/PaymentRetryService.java
@@ -1,0 +1,92 @@
+package com.yes25.yes255orderpaymentserver.application.service.strategy.payment;
+
+import com.yes25.yes255orderpaymentserver.application.service.queue.producer.MessageProducer;
+import com.yes25.yes255orderpaymentserver.common.exception.EntityNotFoundException;
+import com.yes25.yes255orderpaymentserver.common.exception.payload.ErrorStatus;
+import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.TossAdaptor;
+import com.yes25.yes255orderpaymentserver.persistance.domain.OrderBook;
+import com.yes25.yes255orderpaymentserver.persistance.domain.OrderCoupon;
+import com.yes25.yes255orderpaymentserver.persistance.domain.Payment;
+import com.yes25.yes255orderpaymentserver.persistance.domain.PaymentDetail;
+import com.yes25.yes255orderpaymentserver.persistance.repository.PaymentDetailRepository;
+import com.yes25.yes255orderpaymentserver.persistance.repository.PaymentRepository;
+import com.yes25.yes255orderpaymentserver.presentation.dto.request.CreatePaymentRequest;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class PaymentRetryService {
+
+    private static final int MAX_ATTEMPTS = 60;
+    private static final int RETRY_DELAY_MS = 10000;
+
+    private final MessageProducer messageProducer;
+    private final TossAdaptor tossAdaptor;
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentDetailRepository paymentDetailRepository;
+
+    public void retryPaymentConfirm(CreatePaymentRequest request, String authorizations,
+        JSONObject obj, int attempt, Long paymentId) {
+
+        while (attempt < MAX_ATTEMPTS) {
+            try {
+                Thread.sleep(RETRY_DELAY_MS);
+
+                JSONObject response = tossAdaptor.confirmPayment(authorizations, obj.toString());
+
+                Payment payment = paymentRepository.findById(paymentId)
+                    .orElseThrow(() -> new EntityNotFoundException(ErrorStatus.toErrorStatus(
+                        "결제 정보를 찾을 수 없습니다. 결제 ID : " + paymentId, 404, LocalDateTime.now())));
+
+                PaymentDetail paymentDetail = PaymentDetail.from(response, payment);
+                paymentDetailRepository.save(paymentDetail);
+
+                log.info("결제가 성공적으로 이루어졌습니다. {}", paymentId);
+
+                return;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (Exception ignore) {
+                log.error("error", ignore);
+                attempt++;
+            }
+        }
+
+        log.error("결제 재시도 최종 실패 : {}", request);
+        Payment payment = paymentRepository.findById(paymentId)
+            .orElseThrow(() -> new EntityNotFoundException(ErrorStatus.toErrorStatus(
+                "결제 정보를 찾을 수 없습니다. 결제 ID : " + paymentId, 404, LocalDateTime.now())));
+
+        sendPaymentRetryFailureMessage(payment);
+    }
+
+    private void sendPaymentRetryFailureMessage(Payment payment) {
+        List<Long> bookIds = payment.getOrder().getOrderBooks().stream()
+            .map(OrderBook::getBookId)
+            .toList();
+
+        List<Integer> quantities = payment.getOrder().getOrderBooks().stream()
+            .map(OrderBook::getOrderBookQuantity)
+            .toList();
+
+        List<Long> couponIds = payment.getOrder().getOrderCoupons().stream()
+            .map(OrderCoupon::getUserCouponId)
+            .toList();
+
+        BigDecimal point = payment.getOrder().getPoints();
+        BigDecimal purePrice = payment.getOrder().getPurePrice();
+
+        messageProducer.sendOrderCancelMessageByUser(bookIds, quantities, couponIds, point, purePrice);
+    }
+}

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/CancelStatusStrategy.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/CancelStatusStrategy.java
@@ -46,9 +46,9 @@ public class CancelStatusStrategy implements OrderStatusStrategy {
 
         log.info("사용자 요청으로 인해 결제 취소를 진행합니다.");
 
-        if (order.getPayment().getPaymentAmount().compareTo(BigDecimal.ZERO) != 0) {
+        if (order.getPayment().getPaymentDetail().getPaymentAmount().compareTo(BigDecimal.ZERO) != 0) {
             paymentContext.cancelPayment(order.getPayment().getPaymentKey(), "사용자 요청",
-                order.getPayment().getPaymentAmount().intValue(),
+                order.getPayment().getPaymentDetail().getPaymentAmount().intValue(),
                 order.getOrderId(), request.paymentProvider().name().toLowerCase());
         }
 

--- a/src/main/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/ReturnStatusStrategy.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/ReturnStatusStrategy.java
@@ -64,7 +64,7 @@ public class ReturnStatusStrategy implements OrderStatusStrategy {
             throw new AccessDeniedException("반품 가능 기간이 지났습니다. 주문 ID : " + order.getOrderId());
         }
 
-        return order.getPayment().getPaymentAmount()
+        return order.getPayment().getPaymentDetail().getPaymentAmount()
             .subtract(refundPolicy.getShippingPolicyFee());
     }
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/common/config/RedissonConfig.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/common/config/RedissonConfig.java
@@ -15,6 +15,7 @@ public class RedissonConfig {
         config.useSingleServer()
             .setAddress("redis://133.186.241.167:6379")
             .setPassword("*N2vya7H@muDTwdNMR!")
+            .setDatabase(18)
             .setConnectionPoolSize(64)
             .setConnectionMinimumIdleSize(24);
 

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/Payment.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/Payment.java
@@ -1,6 +1,7 @@
 package com.yes25.yes255orderpaymentserver.persistance.domain;
 
 import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.PaymentProvider;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -8,14 +9,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.json.simple.JSONObject;
 
 @Entity
 @Getter
@@ -30,55 +27,32 @@ public class Payment {
     private String paymentKey;
 
     @Column(nullable = false)
-    private BigDecimal paymentAmount;
-
-    @Column(nullable = false)
-    private LocalDateTime approveAt;
-
-    @Column(nullable = false)
-    private LocalDateTime requestedAt;
-
-    @Column(nullable = false)
-    private String paymentMethod;
-
-    @Column(nullable = false)
     private String preOrderId;
 
     @Column(nullable = false)
     private String paymentProvider;
+
+    @OneToOne(mappedBy = "payment", cascade = CascadeType.ALL)
+    private PaymentDetail paymentDetail;
 
     @OneToOne
     @JoinColumn(name = "order_id", referencedColumnName = "order_id")
     private Order order;
 
     @Builder
-    public Payment(Long paymentId, String paymentKey, BigDecimal paymentAmount,
-        LocalDateTime approveAt,
-        LocalDateTime requestedAt, String paymentMethod, String preOrderId, String paymentProvider,
-        Order order) {
+    public Payment(Long paymentId, String paymentKey, String preOrderId, String paymentProvider,
+        PaymentDetail paymentDetail, Order order) {
         this.paymentId = paymentId;
         this.paymentKey = paymentKey;
-        this.paymentAmount = paymentAmount;
-        this.approveAt = approveAt;
-        this.requestedAt = requestedAt;
-        this.paymentMethod = paymentMethod;
         this.preOrderId = preOrderId;
         this.paymentProvider = paymentProvider;
+        this.paymentDetail = paymentDetail;
         this.order = order;
     }
 
-    public static Payment from(JSONObject jsonObject, PaymentProvider paymentProvider) {
-        DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
-        LocalDateTime approvedAt = LocalDateTime.parse((String) jsonObject.get("approvedAt"), formatter);
-        LocalDateTime requestedAt = LocalDateTime.parse((String) jsonObject.get("requestedAt"), formatter);
-
+    public static Payment from(PaymentProvider paymentProvider, String paymentKey) {
         return Payment.builder()
-            .paymentAmount(BigDecimal.valueOf((Integer) jsonObject.get("totalAmount")))
-            .paymentKey((String) jsonObject.get("paymentKey"))
-            .approveAt(approvedAt)
-            .requestedAt(requestedAt)
-            .paymentMethod((String) jsonObject.get("method"))
-            .preOrderId((String) jsonObject.get("orderId"))
+            .paymentKey(paymentKey)
             .paymentProvider(paymentProvider.name().toLowerCase())
             .build();
     }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/Payment.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/Payment.java
@@ -27,9 +27,6 @@ public class Payment {
     private String paymentKey;
 
     @Column(nullable = false)
-    private String preOrderId;
-
-    @Column(nullable = false)
     private String paymentProvider;
 
     @OneToOne(mappedBy = "payment", cascade = CascadeType.ALL)
@@ -40,11 +37,10 @@ public class Payment {
     private Order order;
 
     @Builder
-    public Payment(Long paymentId, String paymentKey, String preOrderId, String paymentProvider,
+    public Payment(Long paymentId, String paymentKey, String paymentProvider,
         PaymentDetail paymentDetail, Order order) {
         this.paymentId = paymentId;
         this.paymentKey = paymentKey;
-        this.preOrderId = preOrderId;
         this.paymentProvider = paymentProvider;
         this.paymentDetail = paymentDetail;
         this.order = order;

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/PaymentDetail.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/PaymentDetail.java
@@ -1,0 +1,72 @@
+package com.yes25.yes255orderpaymentserver.persistance.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.json.simple.JSONObject;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PaymentDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long paymentDetailId;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "payment_id", nullable = false)
+    private Payment payment;
+
+    @Column(nullable = false)
+    private BigDecimal paymentAmount;
+
+    @Column(nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime approveAt;
+
+    @Column(nullable = false)
+    private String paymentMethod;
+
+    @Builder
+    public PaymentDetail(Long paymentDetailId, Payment payment, BigDecimal paymentAmount,
+        LocalDateTime requestedAt,
+        LocalDateTime approveAt, String paymentMethod) {
+        this.paymentDetailId = paymentDetailId;
+        this.payment = payment;
+        this.paymentAmount = paymentAmount;
+        this.requestedAt = requestedAt;
+        this.approveAt = approveAt;
+        this.paymentMethod = paymentMethod;
+    }
+
+
+    public static PaymentDetail from(JSONObject jsonObject, Payment payment) {
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
+        LocalDateTime approvedAt = LocalDateTime.parse((String) jsonObject.get("approvedAt"), formatter);
+        LocalDateTime requestedAt = LocalDateTime.parse((String) jsonObject.get("requestedAt"), formatter);
+
+        return PaymentDetail.builder()
+            .paymentAmount(BigDecimal.valueOf((Integer) jsonObject.get("totalAmount")))
+            .approveAt(approvedAt)
+            .requestedAt(requestedAt)
+            .paymentMethod((String) jsonObject.get("method"))
+            .payment(payment)
+            .build();
+    }
+}

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/enumtype/OrderStatusType.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/domain/enumtype/OrderStatusType.java
@@ -6,5 +6,6 @@ public enum OrderStatusType {
     DONE,
     REFUND,
     CANCEL,
-    RETURN
+    RETURN,
+    PAYMENT_CONFIRM_DENIED
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/repository/PaymentDetailRepository.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/repository/PaymentDetailRepository.java
@@ -1,0 +1,8 @@
+package com.yes25.yes255orderpaymentserver.persistance.repository;
+
+import com.yes25.yes255orderpaymentserver.persistance.domain.PaymentDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, Long> {
+
+}

--- a/src/main/java/com/yes25/yes255orderpaymentserver/persistance/repository/PaymentRepository.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/persistance/repository/PaymentRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
-    Optional<Payment> findByPreOrderId(String orderId);
+    Optional<Payment> findByPaymentKey(String paymentKey);
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/request/CreatePaymentRequest.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/request/CreatePaymentRequest.java
@@ -18,7 +18,6 @@ public record CreatePaymentRequest(String paymentKey,
 
     public Payment toEntity() {
         return Payment.builder()
-            .preOrderId(orderId)
             .paymentKey(paymentKey)
             .paymentProvider(paymentProvider.name().toLowerCase())
             .build();

--- a/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/request/CreatePaymentRequest.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/request/CreatePaymentRequest.java
@@ -1,6 +1,7 @@
 package com.yes25.yes255orderpaymentserver.presentation.dto.request;
 
 import com.yes25.yes255orderpaymentserver.persistance.domain.Payment;
+import com.yes25.yes255orderpaymentserver.persistance.domain.PaymentDetail;
 import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.PaymentProvider;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -16,12 +17,18 @@ public record CreatePaymentRequest(String paymentKey,
     public Payment toEntity() {
         return Payment.builder()
             .preOrderId(orderId)
-            .paymentAmount(BigDecimal.ZERO)
             .paymentKey(paymentKey)
-            .requestedAt(LocalDateTime.now())
-            .approveAt(LocalDateTime.now())
             .paymentProvider(paymentProvider.name().toLowerCase())
-            .paymentMethod("일반 결제 - 0원")
+            .build();
+    }
+
+    public PaymentDetail zeroPay(Payment payment) {
+        return PaymentDetail.builder()
+            .paymentAmount(BigDecimal.ZERO)
+            .approveAt(LocalDateTime.now())
+            .requestedAt(LocalDateTime.now())
+            .paymentMethod("0원 결제")
+            .payment(payment)
             .build();
     }
 }

--- a/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/request/CreatePaymentRequest.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/request/CreatePaymentRequest.java
@@ -6,7 +6,9 @@ import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.PaymentPro
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Builder;
 
+@Builder
 public record CreatePaymentRequest(String paymentKey,
                                    String orderId,
                                    String amount,

--- a/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/response/ReadOrderDetailResponse.java
+++ b/src/main/java/com/yes25/yes255orderpaymentserver/presentation/dto/response/ReadOrderDetailResponse.java
@@ -42,7 +42,8 @@ public record ReadOrderDetailResponse(
     List<Integer> quantities,
     List<BigDecimal> bookPrices,
     CancelStatus cancelStatus,
-    PaymentProvider paymentProvider) {
+    PaymentProvider paymentProvider,
+    List<Long> bookIds) {
 
     public static ReadOrderDetailResponse of(Order order, List<ReadBookResponse> responses,
         List<OrderBook> orderBooks) {
@@ -57,6 +58,10 @@ public record ReadOrderDetailResponse(
 
     private static ReadOrderDetailResponse buildResponse(Order order, List<ReadBookResponse> responses,
         List<OrderBook> orderBooks, CancelStatus cancelStatus) {
+        List<Long> bookIds = responses.stream()
+            .map(ReadBookResponse::bookId)
+            .toList();
+
         List<String> bookNames = responses.stream()
             .map(ReadBookResponse::bookName)
             .toList();
@@ -103,6 +108,7 @@ public record ReadOrderDetailResponse(
             .bookPrices(bookPrices)
             .cancelStatus(cancelStatus)
             .paymentProvider(PaymentProvider.from(order.getPayment().getPaymentProvider()))
+            .bookIds(bookIds)
             .build();
     }
 }

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/context/OrderStatusContextTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/context/OrderStatusContextTest.java
@@ -69,8 +69,6 @@ class OrderStatusContextTest {
             .paymentId(1L)
             .preOrderId("order-1234")
             .paymentKey("dsadsad")
-            .paymentAmount(BigDecimal.valueOf(10000))
-            .paymentMethod("카드")
             .build();
 
         order = Order.builder()

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/context/OrderStatusContextTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/context/OrderStatusContextTest.java
@@ -67,7 +67,6 @@ class OrderStatusContextTest {
 
         payment = Payment.builder()
             .paymentId(1L)
-            .preOrderId("order-1234")
             .paymentKey("dsadsad")
             .build();
 

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/AdminOrderServiceImplTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/AdminOrderServiceImplTest.java
@@ -20,6 +20,7 @@ import com.yes25.yes255orderpaymentserver.persistance.domain.Order;
 import com.yes25.yes255orderpaymentserver.persistance.domain.OrderBook;
 import com.yes25.yes255orderpaymentserver.persistance.domain.OrderStatus;
 import com.yes25.yes255orderpaymentserver.persistance.domain.Payment;
+import com.yes25.yes255orderpaymentserver.persistance.domain.PaymentDetail;
 import com.yes25.yes255orderpaymentserver.persistance.domain.Refund;
 import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.CancelStatus;
 import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.OrderStatusType;
@@ -89,13 +90,19 @@ class AdminOrderServiceImplTest {
 
     @BeforeEach
     void setUp() {
+        PaymentDetail paymentDetail = PaymentDetail.builder()
+            .paymentDetailId(1L)
+            .paymentAmount(BigDecimal.ZERO)
+            .paymentMethod("카드")
+            .payment(payment)
+            .build();
+
         payment = Payment.builder()
             .paymentId(1L)
-            .paymentMethod("카드")
             .preOrderId("1")
             .paymentKey("qwer")
-            .paymentAmount(BigDecimal.valueOf(10000))
             .paymentProvider(PaymentProvider.TOSS.name())
+            .paymentDetail(paymentDetail)
             .build();
 
         orderBook = OrderBook.builder()

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/AdminOrderServiceImplTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/AdminOrderServiceImplTest.java
@@ -99,7 +99,6 @@ class AdminOrderServiceImplTest {
 
         payment = Payment.builder()
             .paymentId(1L)
-            .preOrderId("1")
             .paymentKey("qwer")
             .paymentProvider(PaymentProvider.TOSS.name())
             .paymentDetail(paymentDetail)

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImplTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImplTest.java
@@ -163,9 +163,7 @@ class OrderServiceImplTest {
             .paymentId(1L)
             .preOrderId("order-1234")
             .paymentKey("dsadsad")
-            .paymentAmount(BigDecimal.valueOf(10000))
             .paymentProvider(PaymentProvider.TOSS.name().toLowerCase())
-            .paymentMethod("카드")
             .build();
 
         order = Order.builder()

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImplTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/OrderServiceImplTest.java
@@ -161,7 +161,6 @@ class OrderServiceImplTest {
 
         payment = Payment.builder()
             .paymentId(1L)
-            .preOrderId("order-1234")
             .paymentKey("dsadsad")
             .paymentProvider(PaymentProvider.TOSS.name().toLowerCase())
             .build();
@@ -213,7 +212,7 @@ class OrderServiceImplTest {
         when(takeoutRepository.findByTakeoutName(anyString())).thenReturn(Optional.of(takeout));
         when(orderRepository.save(any(Order.class))).thenReturn(order);
         when(orderBookRepository.saveAll(anyList())).thenReturn(orderBooks);
-        when(paymentRepository.findByPreOrderId(anyString())).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByPaymentKey(anyString())).thenReturn(Optional.of(payment));
 
         // when
         orderService.createOrder(preOrder, purePrice, response);

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/TossPaymentProcessorTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/TossPaymentProcessorTest.java
@@ -96,7 +96,6 @@ class TossPaymentProcessorTest {
         payment = Payment.builder()
             .paymentId(1L)
             .paymentKey("paymentKey")
-            .preOrderId("orderId")
             .paymentDetail(paymentDetail)
             .build();
 

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/TossPaymentProcessorTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/impl/TossPaymentProcessorTest.java
@@ -9,12 +9,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.yes25.yes255orderpaymentserver.application.dto.request.CancelPaymentRequest;
+import com.yes25.yes255orderpaymentserver.application.service.queue.producer.MessageProducer;
 import com.yes25.yes255orderpaymentserver.application.service.strategy.payment.impl.TossPayment;
 import com.yes25.yes255orderpaymentserver.common.jwt.JwtUserDetails;
 import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.BookAdaptor;
 import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.TossAdaptor;
 import com.yes25.yes255orderpaymentserver.persistance.domain.Payment;
+import com.yes25.yes255orderpaymentserver.persistance.domain.PaymentDetail;
 import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.PaymentProvider;
+import com.yes25.yes255orderpaymentserver.persistance.repository.PaymentDetailRepository;
 import com.yes25.yes255orderpaymentserver.persistance.repository.PaymentRepository;
 import com.yes25.yes255orderpaymentserver.presentation.dto.request.CreatePaymentRequest;
 import com.yes25.yes255orderpaymentserver.presentation.dto.response.CreatePaymentResponse;
@@ -51,6 +54,9 @@ class TossPaymentProcessorTest {
     private TossAdaptor tossAdaptor;
 
     @Mock
+    private MessageProducer messageProducer;
+
+    @Mock
     private SecurityContext securityContext;
 
     @Mock
@@ -58,6 +64,9 @@ class TossPaymentProcessorTest {
 
     @Mock
     private HttpURLConnection mockConnection;
+
+    @Mock
+    private PaymentDetailRepository paymentDetailRepository;
 
     @InjectMocks
     private TossPayment tossPaymentProcessor;
@@ -72,20 +81,23 @@ class TossPaymentProcessorTest {
         createPaymentRequest = new CreatePaymentRequest(
             "paymentKey",
             "orderId",
-            "amount",
+            "10000",
             PaymentProvider.TOSS,
             List.of(1L, 2L),
             List.of(1, 2)
         );
 
+        PaymentDetail paymentDetail = PaymentDetail.builder()
+            .paymentDetailId(1L)
+            .paymentAmount(BigDecimal.ZERO)
+            .paymentMethod("카드")
+            .build();
+
         payment = Payment.builder()
             .paymentId(1L)
             .paymentKey("paymentKey")
-            .paymentAmount(BigDecimal.valueOf(10000))
-            .approveAt(LocalDateTime.now())
-            .requestedAt(LocalDateTime.now())
-            .paymentMethod("카드")
             .preOrderId("orderId")
+            .paymentDetail(paymentDetail)
             .build();
 
         jsonObject = new JSONObject();

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/queue/producer/MessageProducerTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/queue/producer/MessageProducerTest.java
@@ -49,6 +49,7 @@ class MessageProducerTest {
         String authToken = "authToken";
         String cartId = "cartId";
 
+        when(preOrder.getCouponIds()).thenReturn(List.of(1L));
         when(preOrder.getPoints()).thenReturn(new BigDecimal("100"));
         when(preOrder.getBookIds()).thenReturn(List.of(1L, 2L));
         when(preOrder.getQuantities()).thenReturn(List.of(1, 2));

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/payment/PaymentRetryServiceTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/payment/PaymentRetryServiceTest.java
@@ -1,0 +1,221 @@
+package com.yes25.yes255orderpaymentserver.application.service.strategy.payment;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.yes25.yes255orderpaymentserver.application.service.queue.producer.MessageProducer;
+import com.yes25.yes255orderpaymentserver.common.exception.EntityNotFoundException;
+import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.TossAdaptor;
+import com.yes25.yes255orderpaymentserver.persistance.domain.Order;
+import com.yes25.yes255orderpaymentserver.persistance.domain.OrderBook;
+import com.yes25.yes255orderpaymentserver.persistance.domain.OrderCoupon;
+import com.yes25.yes255orderpaymentserver.persistance.domain.OrderStatus;
+import com.yes25.yes255orderpaymentserver.persistance.domain.Payment;
+import com.yes25.yes255orderpaymentserver.persistance.domain.PaymentDetail;
+import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.PaymentProvider;
+import com.yes25.yes255orderpaymentserver.persistance.repository.OrderStatusRepository;
+import com.yes25.yes255orderpaymentserver.persistance.repository.PaymentDetailRepository;
+import com.yes25.yes255orderpaymentserver.persistance.repository.PaymentRepository;
+import com.yes25.yes255orderpaymentserver.presentation.dto.request.CreatePaymentRequest;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentRetryServiceTest {
+
+    @Mock
+    private MessageProducer messageProducer;
+
+    @Mock
+    private TossAdaptor tossAdaptor;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentDetailRepository paymentDetailRepository;
+
+    @Mock
+    private OrderStatusRepository orderStatusRepository;
+
+    private PaymentRetryService paymentRetryService;
+    private CreatePaymentRequest createPaymentRequest;
+    private String authorizations;
+    private JSONObject object;
+    private int attempt;
+    private int maxAttempt;
+    private int retryDelayMs;
+
+    @BeforeEach
+    void setUp() {
+        paymentRetryService = new PaymentRetryService(messageProducer, tossAdaptor, paymentRepository, paymentDetailRepository, orderStatusRepository);
+
+        createPaymentRequest = CreatePaymentRequest.builder()
+            .paymentKey("key")
+            .amount("10000")
+            .paymentProvider(PaymentProvider.TOSS)
+            .bookIds(List.of(1L))
+            .orderId("order")
+            .quantities(List.of(1))
+            .build();
+
+        object = new JSONObject();
+
+        authorizations = "auth";
+        attempt = 0;
+        maxAttempt = 3;
+        retryDelayMs = 100;
+    }
+
+    @DisplayName("결제 재시도를 성공적으로 수행하는지 확인한다.")
+    @Test
+    void retryPaymentConfirmSuccess() {
+        // given
+        JSONObject responseObject = new JSONObject();
+        responseObject.put("approvedAt", "2023-07-01T10:15:30");
+        responseObject.put("requestedAt", "2023-07-01T10:10:30");
+        responseObject.put("totalAmount", 10000);
+        responseObject.put("method", "CARD");
+
+        when(tossAdaptor.confirmPayment(anyString(), anyString())).thenReturn(responseObject);
+
+        Payment payment = mock(Payment.class);
+
+        when(paymentRepository.findById(anyLong())).thenReturn(Optional.of(payment));
+
+        // when
+        paymentRetryService.retryPaymentConfirm(createPaymentRequest, authorizations, object, attempt, 1L, maxAttempt, retryDelayMs);
+
+        // then
+        verify(tossAdaptor, times(1)).confirmPayment(anyString(), anyString());
+        verify(paymentRepository, times(1)).findById(anyLong());
+        verify(paymentDetailRepository, times(1)).save(any(PaymentDetail.class));
+    }
+
+    @DisplayName("결제 정보를 찾을 수 없을 경우 예외를 반환하는지 확인한다.")
+    @Test
+    void retryPaymentConfirmFailureWhenPaymentNotFound() {
+        // given
+        JSONObject responseObject = new JSONObject();
+        responseObject.put("approvedAt", "2023-07-01T10:15:30");
+        responseObject.put("requestedAt", "2023-07-01T10:10:30");
+        responseObject.put("totalAmount", 10000);
+        responseObject.put("method", "CARD");
+
+        when(tossAdaptor.confirmPayment(anyString(), anyString())).thenReturn(responseObject);
+        when(paymentRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // when && then
+        assertThatThrownBy(() ->
+            paymentRetryService.retryPaymentConfirm(createPaymentRequest, authorizations, object, attempt, 1L, maxAttempt, retryDelayMs)
+        ).isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @DisplayName("결제 재시도가 중단 예외(InterruptedException)에 의해 실패하고 적절하게 처리되는지 확인한다.")
+    @Test
+    void retryPaymentConfirmFailureWhenInterruptedException() {
+        // given && when
+        Thread testThread = new Thread(() -> {
+            paymentRetryService.retryPaymentConfirm(createPaymentRequest, authorizations, object, attempt, 1L, maxAttempt, retryDelayMs);
+        });
+
+        testThread.start();
+        testThread.interrupt();
+
+        try {
+            testThread.join();
+        } catch (InterruptedException ignore) {}
+
+        // then
+        verify(tossAdaptor, never()).confirmPayment(anyString(), anyString());
+        verify(messageProducer, never()).sendOrderCancelMessageByUser(anyList(), anyList(), anyList(), any(BigDecimal.class), any(BigDecimal.class));
+        verify(paymentDetailRepository, never()).save(any(PaymentDetail.class));
+    }
+
+
+    @DisplayName("결제 재시도가 실패하고 최종적으로 처리되는지 확인한다.")
+    @Test
+    void retryPaymentConfirmFailure() {
+        // given
+        when(tossAdaptor.confirmPayment(anyString(), anyString())).thenThrow(new RuntimeException("Payment failed"));
+
+        Payment payment = mock(Payment.class);
+        Order order = mock(Order.class);
+        OrderStatus orderStatus = mock(OrderStatus.class);
+
+        when(order.getPoints()).thenReturn(BigDecimal.valueOf(1000));
+        when(order.getPurePrice()).thenReturn(BigDecimal.valueOf(1000));
+
+        when(payment.getOrder()).thenReturn(order);
+
+        OrderBook orderBook = mock(OrderBook.class);
+        when(orderBook.getBookId()).thenReturn(1L);
+        when(orderBook.getOrderBookQuantity()).thenReturn(1);
+
+        OrderCoupon orderCoupon = mock(OrderCoupon.class);
+        when(orderCoupon.getUserCouponId()).thenReturn(1L);
+
+        when(order.getOrderBooks()).thenReturn(List.of(orderBook));
+        when(order.getOrderCoupons()).thenReturn(List.of(orderCoupon));
+
+        when(paymentRepository.findById(anyLong())).thenReturn(Optional.of(payment));
+        when(orderStatusRepository.findByOrderStatusName(anyString())).thenReturn(Optional.of(orderStatus));
+
+        // when
+        paymentRetryService.retryPaymentConfirm(createPaymentRequest, authorizations, object, attempt, 1L, maxAttempt, retryDelayMs);
+
+        // then
+        verify(tossAdaptor, times(maxAttempt)).confirmPayment(anyString(), anyString());
+        verify(messageProducer, times(1)).sendOrderCancelMessageByUser(anyList(), anyList(), anyList(), any(BigDecimal.class), any(BigDecimal.class));
+        verify(paymentDetailRepository, never()).save(any(PaymentDetail.class));
+    }
+
+    @DisplayName("주문 상태를 업데이트할 때, 주문 상태를 찾을 수 없으면 예외를 반환하는지 확인한다.")
+    @Test
+    void retryPaymentConfirmFailureWhenOrderStatusNotFound() {
+        // given
+        when(tossAdaptor.confirmPayment(anyString(), anyString())).thenThrow(new RuntimeException("Payment failed"));
+
+        Payment payment = mock(Payment.class);
+        Order order = mock(Order.class);
+
+        when(order.getPoints()).thenReturn(BigDecimal.valueOf(1000));
+        when(order.getPurePrice()).thenReturn(BigDecimal.valueOf(1000));
+
+        when(payment.getOrder()).thenReturn(order);
+
+        OrderBook orderBook = mock(OrderBook.class);
+        when(orderBook.getBookId()).thenReturn(1L);
+        when(orderBook.getOrderBookQuantity()).thenReturn(1);
+
+        OrderCoupon orderCoupon = mock(OrderCoupon.class);
+        when(orderCoupon.getUserCouponId()).thenReturn(1L);
+
+        when(order.getOrderBooks()).thenReturn(List.of(orderBook));
+        when(order.getOrderCoupons()).thenReturn(List.of(orderCoupon));
+
+        when(paymentRepository.findById(anyLong())).thenReturn(Optional.of(payment));
+        when(orderStatusRepository.findByOrderStatusName(anyString())).thenReturn(Optional.empty());
+
+        // when
+        assertThatThrownBy(() ->
+        paymentRetryService.retryPaymentConfirm(createPaymentRequest, authorizations, object, attempt, 1L, maxAttempt, retryDelayMs)
+        ).isInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/CancelStatusStrategyTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/CancelStatusStrategyTest.java
@@ -90,7 +90,6 @@ class CancelStatusStrategyTest {
 
         payment = Payment.builder()
             .paymentId(1L)
-            .preOrderId("order-1234")
             .paymentKey("dsadsad")
             .paymentDetail(paymentDetail)
             .build();

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/CancelStatusStrategyTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/CancelStatusStrategyTest.java
@@ -15,6 +15,7 @@ import com.yes25.yes255orderpaymentserver.persistance.domain.Order;
 import com.yes25.yes255orderpaymentserver.persistance.domain.OrderBook;
 import com.yes25.yes255orderpaymentserver.persistance.domain.OrderStatus;
 import com.yes25.yes255orderpaymentserver.persistance.domain.Payment;
+import com.yes25.yes255orderpaymentserver.persistance.domain.PaymentDetail;
 import com.yes25.yes255orderpaymentserver.persistance.domain.Takeout;
 import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.OrderStatusType;
 import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.PaymentProvider;
@@ -81,12 +82,17 @@ class CancelStatusStrategyTest {
 
         orderBooks = List.of(orderBook);
 
+        PaymentDetail paymentDetail = PaymentDetail.builder()
+            .paymentDetailId(1L)
+            .paymentAmount(BigDecimal.ZERO)
+            .paymentMethod("카드")
+            .build();
+
         payment = Payment.builder()
             .paymentId(1L)
             .preOrderId("order-1234")
             .paymentKey("dsadsad")
-            .paymentAmount(BigDecimal.valueOf(10000))
-            .paymentMethod("카드")
+            .paymentDetail(paymentDetail)
             .build();
 
         order = Order.builder()

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/RefundStatusStrategyTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/RefundStatusStrategyTest.java
@@ -76,7 +76,6 @@ class RefundStatusStrategyTest {
 
         payment = Payment.builder()
             .paymentId(1L)
-            .preOrderId("order-1234")
             .paymentKey("dsadsad")
             .build();
 

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/RefundStatusStrategyTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/RefundStatusStrategyTest.java
@@ -78,8 +78,6 @@ class RefundStatusStrategyTest {
             .paymentId(1L)
             .preOrderId("order-1234")
             .paymentKey("dsadsad")
-            .paymentAmount(BigDecimal.valueOf(10000))
-            .paymentMethod("카드")
             .build();
 
         order = Order.builder()

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/ReturnStatusStrategyTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/ReturnStatusStrategyTest.java
@@ -14,6 +14,7 @@ import com.yes25.yes255orderpaymentserver.persistance.domain.Order;
 import com.yes25.yes255orderpaymentserver.persistance.domain.OrderBook;
 import com.yes25.yes255orderpaymentserver.persistance.domain.OrderStatus;
 import com.yes25.yes255orderpaymentserver.persistance.domain.Payment;
+import com.yes25.yes255orderpaymentserver.persistance.domain.PaymentDetail;
 import com.yes25.yes255orderpaymentserver.persistance.domain.ShippingPolicy;
 import com.yes25.yes255orderpaymentserver.persistance.domain.Takeout;
 import com.yes25.yes255orderpaymentserver.persistance.domain.enumtype.OrderStatusType;
@@ -79,12 +80,19 @@ class ReturnStatusStrategyTest {
 
         orderBooks = List.of(orderBook);
 
+
+        PaymentDetail paymentDetail = PaymentDetail.builder()
+            .paymentDetailId(1L)
+            .paymentAmount(BigDecimal.ZERO)
+            .paymentMethod("카드")
+            .payment(payment)
+            .build();
+
         payment = Payment.builder()
             .paymentId(1L)
             .preOrderId("order-1234")
             .paymentKey("dsadsad")
-            .paymentAmount(BigDecimal.valueOf(10000))
-            .paymentMethod("카드")
+            .paymentDetail(paymentDetail)
             .build();
 
         order = Order.builder()

--- a/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/ReturnStatusStrategyTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/application/service/strategy/status/impl/ReturnStatusStrategyTest.java
@@ -90,7 +90,6 @@ class ReturnStatusStrategyTest {
 
         payment = Payment.builder()
             .paymentId(1L)
-            .preOrderId("order-1234")
             .paymentKey("dsadsad")
             .paymentDetail(paymentDetail)
             .build();

--- a/src/test/java/com/yes25/yes255orderpaymentserver/common/utils/AsyncSecurityContextUtilsTest.java
+++ b/src/test/java/com/yes25/yes255orderpaymentserver/common/utils/AsyncSecurityContextUtilsTest.java
@@ -11,6 +11,7 @@ import com.yes25.yes255orderpaymentserver.common.jwt.JwtProvider;
 import com.yes25.yes255orderpaymentserver.infrastructure.adaptor.AuthAdaptor;
 import com.yes25.yes255orderpaymentserver.presentation.dto.response.JwtAuthResponse;
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,6 +46,7 @@ class AsyncSecurityContextUtilsTest {
     @BeforeEach
     void setUp() {
         when(message.getMessageProperties()).thenReturn(messageProperties);
+        SecurityContextHolder.clearContext();
     }
 
     @DisplayName("유효한 토큰이 주어졌을 때 보안 컨텍스트가 올바르게 설정되는지 확인한다")
@@ -58,6 +61,13 @@ class AsyncSecurityContextUtilsTest {
         when(messageProperties.getHeaders()).thenReturn(Collections.singletonMap("Authorization", authToken));
         when(jwtProvider.getUserNameFromToken(token)).thenReturn(uuid);
         when(authAdaptor.getUserInfoByUUID(uuid)).thenReturn(jwtAuthResponse);
+
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+            uuid,
+            null,
+            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 
         // when
         securityContextUtils.configureSecurityContext(message);


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Rename
- [ ] Test
- [x] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 결제 실패 시, 주문 성공 처리 후 만료시간까지 재시도하는 기능 추가했습니다.
- 토스 페이먼츠 API에 의하면 결제 요청 성공 시, 해당 결제건은 10분동안 유효하도록 설정되어있습니다.
- 기존 코드는 결제 승인에 실패하면 새로운 결제를 시도하도록 구성되어있습니다.
- 만료 전의 결제를 재활용할 수 있을 것 같아 결제 승인에 실패하더라도 주문과 결제 정보는 그대로 저장되도록 변경하였습니다. 그리고, 결제 승인에 대해서는 비동기적으로 호출됩니다.
- 주문은 승인 여부에 상관없이 저장됩니다. 따라서, 후처리 메세지(포인트 적립 및 차감, 쿠폰 사용 처리)가 발행됩니다.
- 만약, 10분 내에 승인이 이루어지지 않으면 주문 후처리를 롤백하고 주문 상태를 결제 승인 실패로 변경합니다.
- 토스 페이먼츠 API는 결제 승인이 이루어지지 않으면 실제 돈은 빠져나가지 않아, 별도의 취소 요청은 보내지 않습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [x] Yes
- [ ] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->